### PR TITLE
Fix failover peer name

### DIFF
--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -5,7 +5,7 @@ subnet <%= network %> netmask <%= mask %> {
   pool
   {
 <% if failover != '' -%>
-    failover peer "<%= failover %>";
+    failover peer "dhcp-failover";
 <% end -%>
 <% range.each do |r| -%>
     range <%= r %>;


### PR DESCRIPTION
Use "dhcp-failover" as failover peer name, if failover != ''