### PR TITLE
Modernize module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,10 @@
 fixtures:
   repositories:
-    concat: 'git://github.com/puppetlabs/puppetlabs-concat.git'
-    stdlib: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
+    concat:
+      repo: 'git://github.com/puppetlabs/puppetlabs-concat.git'
+      ref: '1.1.0'
+    stdlib:
+      repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
+      ref: '4.1.0'
   symlinks:
     dhcp: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,31 @@
-pkg/
+# Default .gitignore for Ruby
+*.gem
+*.rbc
+.bundle
+.config
+coverage
+InstalledFiles
+lib/bundler/man
+pkg
+rdoc
+spec/reports
+test/tmp
+test/version_tmp
+tmp
+
+# YARD artifacts
+.yardoc
+_yardoc
+doc/
+
+# Vim
+*.swp
+
+# OS X
+.DS_Store
+
+# Puppet
+coverage/
+spec/fixtures/modules/*
+Gemfile.lock
+spec/fixtures/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+---
+env:
+- PUPPET_VERSION=3.3.2
+- PUPPET_VERSION=3.4.2
+- PUPPET_VERSION=3.5.1
+- PUPPET_VERSION=3.6.0
+notifications:
+email: false
+rvm:
+- 1.8.7
+- 1.9.3
+- 2.0.0
+language: ruby
+before_script: "gem install --no-ri --no-rdoc bundler"
+script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'
+gemfile: Gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,39 @@
 ---
-env:
-- PUPPET_VERSION=3.3.2
-- PUPPET_VERSION=3.4.2
-- PUPPET_VERSION=3.5.1
-- PUPPET_VERSION=3.6.0
-notifications:
-email: false
-rvm:
-- 1.8.7
-- 1.9.3
-- 2.0.0
 language: ruby
-before_script: "gem install --no-ri --no-rdoc bundler"
+
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+
+env:
+  matrix:
+    - PUPPET_GEM_VERSION="~> 3.1.0"
+    - PUPPET_GEM_VERSION="~> 3.2.0"
+    - PUPPET_GEM_VERSION="~> 3.3.0"
+    - PUPPET_GEM_VERSION="~> 3.4.0"
+    - PUPPET_GEM_VERSION="~> 3.5.1"
+    - PUPPET_GEM_VERSION="~> 3.6.0"
+    - PUPPET_GEM_VERSION="~> 3.7.0"
+
+sudo: false
+
 script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'
-gemfile: Gemfile
+
+matrix:
+  fast_finish: true
+  exclude:
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.2.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.3.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.4.0"
+
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 3.3']
+gem 'puppet', puppetversion
+gem 'puppetlabs_spec_helper', '>= 0.1.0'
+gem 'puppet-lint', '>= 0.3.2'
+gem 'facter', '>= 1.7.0', "< 1.8.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,11 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 3.3']
-gem 'puppet', puppetversion
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end
+
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
-gem 'puppet-lint', '>= 0.3.2'
-gem 'facter', '>= 1.7.0', "< 1.8.0"
+gem 'puppet-lint', '>= 1.0.0'
+gem 'facter', '>= 1.7.0'

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Define the server and the zones it will be responsible for.
       dnsdomain    => [
         'dc1.example.net',
         '1.0.10.in-addr.arpa',
-        ],
+      ],
       nameservers  => ['10.0.1.20'],
       ntpservers   => ['us.pool.ntp.org'],
       interfaces   => ['eth0'],
@@ -37,13 +37,13 @@ Define the pool attributes
 ### dhcp::host
 Create host reservations.
 
-    dhcp::host {
-      'server1': mac => "00:50:56:00:00:01", ip => "10.0.1.51";
-      'server2': mac => "00:50:56:00:00:02", ip => "10.0.1.52";
-      'server3': mac => "00:50:56:00:00:03", ip => "10.0.1.53";
+    dhcp::host { 'server1':
+      mac => '00:50:56:00:00:01',
+      ip  => '10.0.1.51',
     }
 
 ## Contributors
 Zach Leslie <zach.leslie@gmail.com>
 Ben Hughes <git@mumble.org.uk>
+Garrett Honeycutt <gh@learnpuppet.com>
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,17 @@
-require 'rake'
 require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+
+desc "Run puppet in noop mode and check for syntax errors."
+task :validate do
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
+  end
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
+  end
+  Dir['templates/**/*.erb'].each do |template|
+    sh "erb -P -x -T '-' #{template} | ruby -c"
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,10 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.relative = true
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
-desc "Run puppet in noop mode and check for syntax errors."
+desc 'Validate manifests, templates, and ruby files'
 task :validate do
   Dir['manifests/**/*.pp'].each do |manifest|
     sh "puppet parser validate --noop #{manifest}"

--- a/manifests/failover.pp
+++ b/manifests/failover.pp
@@ -1,22 +1,28 @@
+# == Class: dhcp::failover
+#
 class dhcp::failover (
   $role                = 'primary',
-  $address             = $ipaddress,
-  $peer_address,
+  $address             = $::ipaddress,
+  $peer_address        = undef,
   $port                = '519',
   $max_response_delay  = '30',
   $max_unacked_updates = '10',
   $mclt                = '300',
   $load_split          = '128',
   $load_balance        = '3',
-  $omapi_key           = ''
+  $omapi_key           = '',
 ) {
 
   include dhcp::params
+
   $dhcp_dir = $dhcp::params::dhcp_dir
+
+  if $peer_address == undef {
+    fail('dhcp::failover::peer_address is undef and must be defined. Suggest adding the key to Hiera.')
+  }
 
   concat::fragment { 'dhcp-conf-failover':
     target  => "${dhcp_dir}/dhcpd.conf",
     content => template('dhcp/dhcpd.conf.failover.erb'),
   }
-
 }

--- a/manifests/failover.pp
+++ b/manifests/failover.pp
@@ -1,9 +1,9 @@
 # == Class: dhcp::failover
 #
 class dhcp::failover (
+  $peer_address,
   $role                = 'primary',
   $address             = $::ipaddress,
-  $peer_address        = undef,
   $port                = '519',
   $max_response_delay  = '30',
   $max_unacked_updates = '10',
@@ -16,10 +16,6 @@ class dhcp::failover (
   include dhcp::params
 
   $dhcp_dir = $dhcp::params::dhcp_dir
-
-  if $peer_address == undef {
-    fail('dhcp::failover::peer_address is undef and must be defined. Suggest adding the key to Hiera.')
-  }
 
   concat::fragment { 'dhcp-conf-failover':
     target  => "${dhcp_dir}/dhcpd.conf",

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -1,3 +1,5 @@
+# == Define: dhcp::host
+#
 define dhcp::host (
   $ip,
   $mac,
@@ -5,6 +7,7 @@ define dhcp::host (
 ) {
 
   $host = $name
+
   include dhcp::params
 
   $dhcp_dir = $dhcp::params::dhcp_dir
@@ -15,4 +18,3 @@ define dhcp::host (
     order   => 10,
   }
 }
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,8 @@
+# == Class: dhcp
+#
 class dhcp (
-  $dnsdomain,
-  $nameservers,
+  $dnsdomain           = [ $::domain ],
+  $nameservers         = [ '8.8.8.8', '8.8.4.4' ],
   $ntpservers          = undef,
   $dhcp_conf_header    = 'INTERNAL_TEMPLATE',
   $dhcp_conf_ddns      = 'INTERNAL_TEMPLATE',
@@ -15,7 +17,7 @@ class dhcp (
   $pxefilename         = undef,
   $logfacility         = 'daemon',
   $default_lease_time  = 3600,
-  $max_lease_time      = 86400
+  $max_lease_time      = 86400,
 ) {
   #input validation
   validate_array($dnsdomain)
@@ -23,10 +25,12 @@ class dhcp (
   validate_array($ntpservers)
 
   include dhcp::params
+  include dhcp::monitor
 
-  $dhcp_dir    = $dhcp::params::dhcp_dir
-  $packagename = $dhcp::params::packagename
-  $servicename = $dhcp::params::servicename
+  $dhcp_dir         = $dhcp::params::dhcp_dir
+  $packagename      = $dhcp::params::packagename
+  $servicename      = $dhcp::params::servicename
+  $package_provider = $dhcp::params::package_provider
 
   # Incase people set interface instead of interfaces work around
   # that. If they set both, use interfaces and the user is a unwise
@@ -68,10 +72,7 @@ class dhcp (
 
   package { $packagename:
     ensure   => installed,
-    provider => $operatingsystem ? {
-      default => undef,
-      darwin  => macports
-    }
+    provider => $package_provider,
   }
 
   file { $dhcp_dir:
@@ -80,8 +81,11 @@ class dhcp (
   }
 
   # Only debian and ubuntu have this style of defaults for startup.
-  case $operatingsystem {
-    'debian','ubuntu': {
+  case $::osfamily {
+    default: {
+      fail("dhcp module supports OS families Debian and RedHat. Detect osfamily is <${::osfamily}>.")
+    }
+    'debian': {
       file{ '/etc/default/isc-dhcp-server':
         ensure  => present,
         owner   => 'root',
@@ -92,7 +96,7 @@ class dhcp (
         content => template('dhcp/debian/default_isc-dhcp-server'),
       }
     }
-    'redhat','centos','fedora','Scientific': {
+    'redhat': {
       file{ '/etc/sysconfig/dhcpd':
         ensure  => present,
         owner   => 'root',
@@ -171,7 +175,4 @@ class dhcp (
     subscribe => [Concat["${dhcp_dir}/dhcpd.pools"], Concat["${dhcp_dir}/dhcpd.hosts"], File["${dhcp_dir}/dhcpd.conf"]],
     require   => Package[$packagename],
   }
-
-  include dhcp::monitor
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
 # == Class: dhcp
 #
 class dhcp (
-  $dnsdomain           = [ $::domain ],
+  $dnsdomain           = undef,
   $nameservers         = [ '8.8.8.8', '8.8.4.4' ],
   $ntpservers          = undef,
   $dhcp_conf_header    = 'INTERNAL_TEMPLATE',
@@ -19,8 +19,18 @@ class dhcp (
   $default_lease_time  = 3600,
   $max_lease_time      = 86400,
 ) {
-  #input validation
-  validate_array($dnsdomain)
+
+  if $dnsdomain == undef {
+    if $::domain {
+      $dnsdomain_real = [ $::domain ]
+    } else {
+      fail('dhcp::dnsdomain must be set and domain fact is missing to use as a default value.')
+    }
+  } else {
+    $dnsdomain_real = $dnsdomain
+  }
+  validate_array($dnsdomain_real)
+
   validate_array($nameservers)
   validate_array($ntpservers)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,10 +1,13 @@
+# == Class: dhcp::params
+#
 class dhcp::params {
 
   case $::operatingsystem {
     'debian': {
-      $dhcp_dir    = '/etc/dhcp'
-      $packagename = 'isc-dhcp-server'
-      $servicename = 'isc-dhcp-server'
+      $dhcp_dir         = '/etc/dhcp'
+      $packagename      = 'isc-dhcp-server'
+      $servicename      = 'isc-dhcp-server'
+      $package_provider = undef
     }
     'ubuntu': {
       if versioncmp($::operatingsystemrelease, '12.04') >= 0 {
@@ -12,24 +15,30 @@ class dhcp::params {
       } else {
         $dhcp_dir    = '/etc/dhcp3'
       }
-      $packagename = 'isc-dhcp-server'
-      $servicename = 'isc-dhcp-server'
+      $packagename      = 'isc-dhcp-server'
+      $servicename      = 'isc-dhcp-server'
+      $package_provider = undef
     }
     'darwin': {
-      $dhcp_dir    = '/opt/local/etc/dhcp'
-      $packagename = 'dhcp'
-      $servicename = 'org.macports.dhcpd'
+      $dhcp_dir         = '/opt/local/etc/dhcp'
+      $packagename      = 'dhcp'
+      $servicename      = 'org.macports.dhcpd'
+      $package_provider = 'macports'
     }
     'freebsd': {
-      $dhcp_dir    = '/usr/local/etc'
-      $packagename = 'net/isc-dhcp42-server'
-      $servicename = 'isc-dhcpd'
+      $dhcp_dir         = '/usr/local/etc'
+      $packagename      = 'net/isc-dhcp42-server'
+      $servicename      = 'isc-dhcpd'
+      $package_provider = undef
     }
     'redhat','fedora','centos': {
-      $dhcp_dir    = '/etc/dhcp'
-      $packagename = 'dhcp'
-      $servicename = 'dhcpd'
+      $dhcp_dir         = '/etc/dhcp'
+      $packagename      = 'dhcp'
+      $servicename      = 'dhcpd'
+      $package_provider = undef
+    }
+    default: {
+      fail('dhcp is supported on the following OS\'s: Debian, Ubuntu, Darwin, FreeBSD, RedHat, Fedora, and CentOS.')
     }
   }
-
 }

--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -1,3 +1,5 @@
+# == Define: dhcp::pool
+#
 define dhcp::pool (
   $network,
   $mask,
@@ -16,6 +18,4 @@ define dhcp::pool (
     target  => "${dhcp_dir}/dhcpd.pools",
     content => template('dhcp/dhcpd.pool.erb'),
   }
-
 }
-

--- a/spec/classes/dhcp_spec.rb
+++ b/spec/classes/dhcp_spec.rb
@@ -5,6 +5,7 @@ describe 'dhcp', :type => :class do
     let :facts do
       {
         :osfamily               => 'RedHat',
+        :operatingsystem        => 'RedHat',
         :operatingsystemrelease => '6',
         :concat_basedir         => '/dne',
       }
@@ -27,7 +28,6 @@ describe 'dhcp', :type => :class do
         'logfacility'         => 'daemon',
         'default_lease_time'  => '3600',
         'max_lease_time'      => '86400',
-        'failover'            => ''
       }
     end
     let :params do
@@ -47,14 +47,11 @@ describe 'dhcp', :type => :class do
       ['dhcp','dhcp::monitor'].each do |dhclasses|
         it {should contain_class(dhclasses)}
       end
-      ['/dhcpd.pools','/dhcpd.hosts'].each do |concats|
+      ['/etc/dhcp/dhcpd.pools','/etc/dhcp/dhcpd.hosts'].each do |concats|
         it {should contain_concat(concats)}
       end
       ['dhcp-conf-pxe','dhcp-conf-extra'].each do |frags|
         it {should contain_concat__fragment(frags)}
-      end
-      ['/dhcpd.conf','/dhcpd.pools'].each do |files|
-        it {should contain_file (files)}
       end
     end
   end

--- a/spec/defines/host_spec.rb
+++ b/spec/defines/host_spec.rb
@@ -4,7 +4,11 @@ describe 'dhcp::host', :type => :define do
   let :title do
     'test_host'
   end
-  let(:facts) {{ :concat_basedir => '/dne' }}
+  let(:facts) do
+    { :concat_basedir  => '/dne',
+      :operatingsystem => 'debian',
+    }
+  end
   let :params do
     {
       'ip'      => '1.2.3.4',
@@ -13,7 +17,5 @@ describe 'dhcp::host', :type => :define do
     }
   end
 
-  it {
-    should contain_concat__fragment("dhcp_host_#{title}")
-  }
+  it { should contain_concat__fragment("dhcp_host_#{title}") }
 end

--- a/spec/defines/pool_spec.rb
+++ b/spec/defines/pool_spec.rb
@@ -4,7 +4,11 @@ describe 'dhcp::pool', :type => :define do
   let :title do
     'test_pool'
   end
-  let(:facts) {{ :concat_basedir => '/dne' }}
+  let(:facts) do
+    { :concat_basedir => '/dne',
+      :operatingsystem => 'debian',
+    }
+  end
   let :params do
     {
       'gateway'  => '1.1.1.1',
@@ -14,7 +18,5 @@ describe 'dhcp::pool', :type => :define do
     }
   end
 
-  it {
-    should contain_concat__fragment("dhcp_pool_#{title}")
-  }
+  it { should contain_concat__fragment("dhcp_pool_#{title}") }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,1 @@
-require 'rspec-puppet'
-
-fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
-
-RSpec.configure do |c|
-  c.module_path = File.join(fixture_path, 'modules')
-  c.manifest_dir = File.join(fixture_path, 'manifests')
-end
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/templates/dhcpd.conf-header.erb
+++ b/templates/dhcpd.conf-header.erb
@@ -10,7 +10,7 @@ log-facility <%= @logfacility %>;
 # ----------
 # Options
 # ----------
-option domain-name "<%= @dnsdomain.first %>";
+option domain-name "<%= @dnsdomain_real.first %>";
 option domain-name-servers <%= @nameservers.join(', ') %>;
 option fqdn.no-client-update on;  # set the "O" and "S" flag bits
 option fqdn.rcode2 255;

--- a/templates/dhcpd.conf.ddns.erb
+++ b/templates/dhcpd.conf.ddns.erb
@@ -10,7 +10,7 @@ use-host-decl-names on;
 
 # Key from bind
 include "<%= @dnsupdatekey %>";
-<% @dnsdomain.each do |dom| -%>
+<% @dnsdomain_real.each do |dom| -%>
 zone <%= dom %>. {
   primary <%= @nameservers.first %>;
   key <%= @dnsupdatekey.split('/').last %>;

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -8,7 +8,7 @@ class { 'dhcp':
   nameservers  => ['10.1.1.10'],
   ntpservers   => ['us.pool.ntp.org'],
   interfaces   => ['eth0'],
-  dnsupdatekey => "/etc/bind/keys.d/$ddnskeyname",
+  dnsupdatekey => "/etc/bind/keys.d/${ddnskeyname}",
   require      => Bind::Key[ $ddnskeyname ],
   pxeserver    => '10.1.1.5',
   pxefilename  => 'pxelinux.0',
@@ -23,7 +23,6 @@ dhcp::pool{ 'example.com':
 
 dhcp::host {
   'gateway':
-    mac => "00:11:22:33:44:55",
-    ip  => "10.1.1.1",
+    mac => '00:11:22:33:44:55',
+    ip  => '10.1.1.1',
 }
-


### PR DESCRIPTION
Taking a quick pass at adding support for Travis, Puppet v3, Ruby 1.8.7,
1.9.3, and 2.0.0 and passing lint. Also specifies the version of concat
(1.1.0) and stdlib (4.1.0).