### PR TITLE
Range must be an array and is expected as such in the template

### DIFF
--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -2,11 +2,13 @@ define dhcp::pool (
   $network,
   $mask,
   $gateway     = '',
-  $range       = '',
+  $range       = [],
   $failover    = '',
   $options     = '',
   $parameters  = ''
 ) {
+  #input validation
+  validate_array($range)
 
   include dhcp::params
 

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -2,13 +2,13 @@
 # <%= @name %> <%= @network %> <%= @mask %>
 #################################
 subnet <%= @network %> netmask <%= @mask %> {
-<% if @range != '' or @failover != '' -%>
+<% if (! @range.empty?) or @failover != '' -%>
   pool
   {
 <% if @failover != '' -%>
     failover peer "<%= @failover %>";
 <% end -%>
-<% if @range != '' -%>
+<% if (! @range.empty?) -%>
 <% @range.each do |r| -%>
     range <%= r %>;
 <% end -%>


### PR DESCRIPTION
We should not allow range to be a string because the templates assert it is an array.
This little patch ensure the proper value, and also update the default range to be an empty array.