### PR TITLE
fix documention for pool definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Define the pool attributes
     dhcp::pool{ 'ops.dc1.example.net':
       network => '10.0.1.0',
       mask    => '255.255.255.0',
-      range   => '10.0.1.100 10.0.1.200',
+      range   => ['10.0.1.100 10.0.1.200'],
       gateway => '10.0.1.1',
     }
 


### PR DESCRIPTION
Pool range not define as array instead of string

Also described at: https://groups.google.com/forum/#!msg/puppet-users/EI6_xFmKxtg/6FOeU4PaEQYJ