### PR TITLE
Add nameservers and pxeserver parameters to pool

### DIFF
--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -5,7 +5,9 @@ define dhcp::pool (
   $range       = '',
   $failover    = '',
   $options     = '',
-  $parameters  = ''
+  $parameters  = '',
+  $nameservers = undef,
+  $pxeserver   = undef,
 ) {
 
   include dhcp::params

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -8,10 +8,12 @@ subnet <%= @network %> netmask <%= @mask %> {
 <% if @failover != '' -%>
     failover peer "<%= @failover %>";
 <% end -%>
-<% if @range != '' -%>
+<% if @range and @range.is_a? Array -%>
 <% @range.each do |r| -%>
     range <%= r %>;
 <% end -%>
+<% elsif @range != '' -%>
+    range <%= @range %>;
 <% end -%>
   }
 <% end -%>

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -34,5 +34,13 @@ subnet <%= @network %> netmask <%= @mask %> {
 <% elsif @parameters != '' -%>
   <%= @parameters %>;
 <% end -%>
+<% if @nameservers and @nameservers.is_a? Array -%>
+  option domain-name-servers <%= @nameservers.sort.join(', ') %>;
+<% elsif @nameservers -%>
+  option domain-name-servers <%= @nameservers %>;
+<% end -%>
+<% if @pxeserver -%>
+  next-server <%= @pxeserver %>;
+<% end -%>
 }
 


### PR DESCRIPTION
This allows users to specify different nameservers and a PXE-server. It also minimizes the differences to theforeman/dhcp which already includes these parameters.