### PR TITLE
ntpservers must be an array instead of undef or the array validation fai...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
 class dhcp (
   $dnsdomain,
   $nameservers,
-  $ntpservers          = undef,
+  $ntpservers          = [],
   $dhcp_conf_header    = 'INTERNAL_TEMPLATE',
   $dhcp_conf_ddns      = 'INTERNAL_TEMPLATE',
   $dhcp_conf_ntp       = 'INTERNAL_TEMPLATE',


### PR DESCRIPTION
Hi,

its a small type fix for the dhcp class. Maybe its useful for you.

Regards
Sascha