### PR TITLE
Normalise MAC addresses to upper case in dhcpd.host

### DIFF
--- a/templates/dhcpd.host.erb
+++ b/templates/dhcpd.host.erb
@@ -1,5 +1,5 @@
 host <%= @host %> {
-  hardware ethernet   <%= @mac %>;
+  hardware ethernet   <%= @mac.upcase %>;
   fixed-address       <%= @ip %>;
   option host-name    "<%= @name %>";
 }


### PR DESCRIPTION
If dhcpd.host.erb normalises all MAC addresses into upper case then this makes duplicate MAC address detection easier.

In our use case XenServer only notices MACs are duplicated if they are the same case so we want to ensure that everywhere MACs are used they are in upper case.