### PR TITLE
Add dnskeyname parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Define the server and the zones it will be responsible for.
       nameservers  => ['10.0.1.20'],
       ntpservers   => ['us.pool.ntp.org'],
       interfaces   => ['eth0'],
-      dnsupdatekey => "/etc/bind/keys.d/$ddnskeyname",
-      require      => Bind::Key[ $ddnskeyname ],
+      dnsupdatekey => '/etc/bind/keys.d/rndc.key',
+      dnskeyname   => 'rndc-key',
+      require      => Bind::Key['rndc-key'],
       pxeserver    => '10.0.1.50',
       pxefilename  => 'pxelinux.0',
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@ class dhcp (
   $interfaces          = undef,
   $interface           = 'NOTSET',
   $dnsupdatekey        = undef,
+  $dnskeyname          = undef,
   $pxeserver           = undef,
   $pxefilename         = undef,
   $logfacility         = 'daemon',
@@ -53,6 +54,14 @@ class dhcp (
     fail ("You need to set \$interfaces in ${module_name}")
   } else {
     $dhcp_interfaces = $interfaces
+  }
+
+  if $dnsupdatekey {
+    $_dnsupdatekey_split    = split($dnsupdatekey, '[/]')
+    $_dnsupdatekey_basename = $_dnsupdatekey_split[-1]
+    $_dnskeyname            = pick($dnskeyname, $_dnsupdatekey_basename)
+  } else {
+    $_dnskeyname            = $dnskeyname
   }
 
   # JJM Decide where to pull the fragment content from.  Either this module, or

--- a/templates/dhcpd.conf.ddns.erb
+++ b/templates/dhcpd.conf.ddns.erb
@@ -13,7 +13,7 @@ include "<%= @dnsupdatekey %>";
 <% @dnsdomain_real.each do |dom| -%>
 zone <%= dom %>. {
   primary <%= @nameservers.first %>;
-  key <%= @dnsupdatekey.split('/').last %>;
+  key <%= @_dnskeyname %>;
 }
 <% end -%>
 <% else -%>


### PR DESCRIPTION
This is an attempt to migrate some of the options currently available in theforeman-dhcp into the puppetlabs module.  This new parameter would at least ease the transition from theforeman-dhcp to puppetlabs-dhcp, which I believe is a goal of the Foreman developers.