### PR TITLE
Set ddns-hostname instead of option host-name for host declarations

### DIFF
--- a/spec/defines/host_spec.rb
+++ b/spec/defines/host_spec.rb
@@ -27,7 +27,7 @@ describe 'dhcp::host', :type => :define do
       "host #{title} {",
       "  hardware ethernet   #{params['mac']};",
       "  fixed-address       #{params['ip']};",
-      "  option host-name    \"#{title}\";",
+      "  ddns-hostname       \"#{title}\";",
       '}',
     ]
     expect(content.split("\n")).to eq(expected_lines)
@@ -49,7 +49,7 @@ describe 'dhcp::host', :type => :define do
         "host #{title} {",
         "  hardware ethernet   #{params['mac']};",
         "  fixed-address       #{params['ip']};",
-        "  option host-name    \"#{title}\";",
+        "  ddns-hostname       \"#{title}\";",
         "  option domain-name-servers 10.0.0.1;",
         "  option vendor-encapsulated-options 01:04:31:41:50:43;",
         '}',

--- a/templates/dhcpd.host.erb
+++ b/templates/dhcpd.host.erb
@@ -1,7 +1,7 @@
 host <%= @host %> {
   hardware ethernet   <%= @mac.upcase %>;
   fixed-address       <%= @ip %>;
-  option host-name    "<%= @name %>";
+  ddns-hostname       "<%= @name %>";
 <% if not @options.empty? -%>
 <% @options.keys.sort.each do |option| -%>
   option <%= option %> <%= @options[option] %>;


### PR DESCRIPTION
This is a non-backwards compatible change, at least in terms of the change that would occur to a DHCP server's config files.  This change is partially to incorporate what's done by theforeman-dhcp into this module (theforeman/puppet-dhcp#21).

Per the man page for dhcpd.conf it seems like ddns-hostname is used first when determing a client's hostname.

       The DHCP server determines the client’s hostname by first looking for a ddns-hostname configuration option, and using that if it is present.  If no such option is present, the server looks for a valid hostname in the FQDN option sent by
       the client.  If one is found, it is used; otherwise, if the client sent a host-name option, that is used.  Otherwise, if there is a host declaration that applies to the client, the name from that declaration will be used.   If  none  of
       these applies, the server will not have a hostname for the client, and will not be able to do a DNS update.

And

            It should be noted here that most DHCP clients completely ignore the host-name option sent by the DHCP server, and there is no way to configure them not to do this.   So you generally have a choice of either not having any hostname
            to client IP address mapping that the client will recognize, or doing DNS updates.   It is beyond the scope of this document to describe how to make this determination.

Be happy to refactor this PR to simply add `ddns-hostname` while also still setting `option host-name`.

I do currently have working DDNS with `ddns-hostname` being set.  If someone can confirm that DDNS still works when setting `option host-name` then this PR may be of no real value.