### PR TITLE
Allow additional options to be specified for dhcp::host

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -3,8 +3,11 @@
 define dhcp::host (
   $ip,
   $mac,
+  $options = {},
   $comment=''
 ) {
+
+  validate_hash($options)
 
   $host = $name
 

--- a/spec/defines/host_spec.rb
+++ b/spec/defines/host_spec.rb
@@ -10,13 +10,51 @@ describe 'dhcp::host', :type => :define do
       :osfamily       => 'RedHat',
     }
   end
-  let :params do
+  let :default_params do
     {
       'ip'      => '1.2.3.4',
       'mac'     => '90:FB:A6:E4:08:9F',
       'comment' => 'test_comment'
     }
   end
+  let(:params) { default_params }
 
   it { should contain_concat__fragment("dhcp_host_#{title}") }
+
+  it 'creates a host declaration' do
+    content = subject.resource('concat::fragment', "dhcp_host_#{title}").send(:parameters)[:content]
+    expected_lines = [
+      "host #{title} {",
+      "  hardware ethernet   #{params['mac']};",
+      "  fixed-address       #{params['ip']};",
+      "  option host-name    \"#{title}\";",
+      '}',
+    ]
+    expect(content.split("\n")).to eq(expected_lines)
+  end
+
+  context 'when options defined' do
+    let(:params) do
+      default_params.merge({
+        :options => {
+          'vendor-encapsulated-options' => '01:04:31:41:50:43',
+          'domain-name-servers'         => '10.0.0.1',
+        }
+      })
+    end
+
+    it 'creates a host declaration with options' do
+      content = subject.resource('concat::fragment', "dhcp_host_#{title}").send(:parameters)[:content]
+      expected_lines = [
+        "host #{title} {",
+        "  hardware ethernet   #{params['mac']};",
+        "  fixed-address       #{params['ip']};",
+        "  option host-name    \"#{title}\";",
+        "  option domain-name-servers 10.0.0.1;",
+        "  option vendor-encapsulated-options 01:04:31:41:50:43;",
+        '}',
+      ]
+      expect(content.split("\n")).to eq(expected_lines)
+    end
+  end
 end

--- a/templates/dhcpd.host.erb
+++ b/templates/dhcpd.host.erb
@@ -2,4 +2,9 @@ host <%= @host %> {
   hardware ethernet   <%= @mac %>;
   fixed-address       <%= @ip %>;
   option host-name    "<%= @name %>";
+<% if not @options.empty? -%>
+<% @options.keys.sort.each do |option| -%>
+  option <%= option %> <%= @options[option] %>;
+<% end -%>
+<% end -%>
 }


### PR DESCRIPTION
This is particularly useful for appliances and hardware with specific requirements when using DHCP.  A good example is in the unit tests, setting `option vendor-encapsulated-options 01:04:31:41:50:43;` is sometimes necessary for APC PDUs to accept a DHCP lease.