### PR TITLE
Fix default ntpservers value to not fail validation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,7 +3,7 @@
 class dhcp (
   $dnsdomain           = undef,
   $nameservers         = [ '8.8.8.8', '8.8.4.4' ],
-  $ntpservers          = undef,
+  $ntpservers          = [],
   $dhcp_conf_header    = 'INTERNAL_TEMPLATE',
   $dhcp_conf_ddns      = 'INTERNAL_TEMPLATE',
   $dhcp_conf_ntp       = 'INTERNAL_TEMPLATE',

--- a/spec/classes/dhcp_spec.rb
+++ b/spec/classes/dhcp_spec.rb
@@ -5,7 +5,6 @@ describe 'dhcp', :type => :class do
     {
       'dnsdomain'           => ['sampledomain.com','1.1.1.in-addr.arpa'],
       'nameservers'         => ['1.1.1.1'],
-      'ntpservers'          => ['time.sample.com'],
       'dhcp_conf_header'    => 'INTERNAL_TEMPLATE',
       'dhcp_conf_ddns'      => 'INTERNAL_TEMPLATE',
       'dhcp_conf_pxe'       => 'INTERNAL_TEMPLATE',
@@ -58,6 +57,32 @@ describe 'dhcp', :type => :class do
         it {should contain_file(files)}
       end
     end
+
+    context 'ntp' do
+      let :params do
+        default_params.merge({
+          :interfaces => ['eth0'],
+        })
+      end
+
+      it 'sets ntp-servers to none' do
+        should contain_concat__fragment('dhcp-conf-ntp').with_content(/^option ntp-servers none;$/)
+      end
+
+      context 'ntpservers defined' do
+        let :params do
+          default_params.merge({
+            :interfaces => ['eth0'],
+            :ntpservers => ['time.sample.com'],
+          })
+        end
+
+        it 'sets ntp-servers' do
+          should contain_concat__fragment('dhcp-conf-ntp').with_content(/^option ntp-servers time.sample.com;$/)
+        end
+      end
+    end
+
     context 'ddns' do
       let :params do
         default_params.merge({

--- a/templates/dhcpd.conf.ntp.erb
+++ b/templates/dhcpd.conf.ntp.erb
@@ -1,5 +1,5 @@
 # BEGIN NTP Section
-<% if @ntpservers -%>
+<% if @ntpservers and ! @ntpservers.empty? -%>
 option ntp-servers <%= @ntpservers.join(', ') %>;
 <% else -%>
 option ntp-servers none;


### PR DESCRIPTION
If `ntpservers` is not defined the `validate_array` validation fails.  I wrote the unit tests and stashed my changes to manifests/init.pp and templates/dhcpd.conf.ntp.erb which resulted in this error:

```
   Puppet::Error:
       "" is not an Array.  It looks to be a String
```

