### PR TITLE
Add omapi_port parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Define the server and the zones it will be responsible for.
       require      => Bind::Key['rndc-key'],
       pxeserver    => '10.0.1.50',
       pxefilename  => 'pxelinux.0',
+      omapi_port   => 7911,
     }
 
 ### dhcp::pool

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@ class dhcp (
   $max_lease_time      = 86400,
   $service_ensure      = running,
   $globaloptions       = '',
+  $omapi_port          = undef,
 ) {
 
   if $dnsdomain == undef {

--- a/spec/classes/dhcp_spec.rb
+++ b/spec/classes/dhcp_spec.rb
@@ -58,6 +58,43 @@ describe 'dhcp', :type => :class do
       end
     end
 
+    context 'header' do
+      let :params do
+        default_params.merge({
+          :interfaces => ['eth0'],
+        })
+      end
+
+      it 'defines dhcp header contents' do
+        verify_concat_fragment_exact_contents(subject, 'dhcp-conf-header', [
+          'authoritative;',
+          'default-lease-time 3600;',
+          'max-lease-time 86400;',
+          'log-facility daemon;',
+          'option domain-name "sampledomain.com";',
+          'option domain-name-servers 1.1.1.1;',
+          'option fqdn.no-client-update on;  # set the "O" and "S" flag bits',
+          'option fqdn.rcode2 255;',
+          'option pxegrub code 150 = text;',
+        ])
+      end
+
+      context 'omapi_port => 7911' do
+        let :params do
+          default_params.merge({
+            :interfaces => ['eth0'],
+            :omapi_port => 7911,
+          })
+        end
+
+        it 'defines dhcp header contents' do
+          verify_concat_fragment_contents(subject, 'dhcp-conf-header', [
+            'omapi-port 7911;',
+          ])
+        end
+      end
+    end
+
     context 'ntp' do
       let :params do
         default_params.merge({

--- a/spec/lib/module_spec_helper.rb
+++ b/spec/lib/module_spec_helper.rb
@@ -1,0 +1,14 @@
+def verify_concat_fragment_contents(subject, title, expected_lines)
+  content = subject.resource('concat::fragment', title).send(:parameters)[:content]
+  (content.split("\n") & expected_lines).should == expected_lines
+end
+
+def verify_concat_fragment_exact_contents(subject, title, expected_lines)
+  content = subject.resource('concat::fragment', title).send(:parameters)[:content]
+  content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }.should == expected_lines
+end
+
+def verify_exact_contents(subject, title, expected_lines)
+  content = subject.resource('file', title).send(:parameters)[:content]
+  content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }.should == expected_lines
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,2 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'lib/module_spec_helper'

--- a/templates/dhcpd.conf-header.erb
+++ b/templates/dhcpd.conf-header.erb
@@ -3,6 +3,9 @@
 # dhcpd.conf
 # ----------
 authoritative;
+<% if @omapi_port -%>
+omapi-port <%= @omapi_port %>;
+<% end -%>
 default-lease-time <%= @default_lease_time %>;
 max-lease-time <%= @max_lease_time %>;
 log-facility <%= @logfacility %>;


### PR DESCRIPTION
Add ability to define `omapi-port`.  I also added some helper functions to unit tests to verify contents of concat::fragment resources.  Hopefully simplify further unit testing of the contents.

This is a partial of what was in #29.