### PR TITLE
Fix in documentation for dhcp::pool. range should be array instead of string

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Define the pool attributes
     dhcp::pool{ 'ops.dc1.example.net':
       network => '10.0.1.0',
       mask    => '255.255.255.0',
-      range   => '10.0.1.100 10.0.1.200',
+      range   => ['10.0.1.100', '10.0.1.200'],
       gateway => '10.0.1.1',
     }
 


### PR DESCRIPTION
I couldn't get the dhcp:pool as is in documentation to work. Using an array instead of a string works.