### PR TITLE
properly put ""quotes around the domain-name option in pool declarations

### DIFF
--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -19,7 +19,7 @@ subnet <%= @network %> netmask <%= @mask %> {
 <% end -%>
 
 <% if @domain_name and !@domain_name.empty? -%>
-  option domain-name <%= @domain_name %>;
+  option domain-name "<%= @domain_name %>";
 <% end -%>
   option subnet-mask <%= @mask %>;
 <% if @gateway != '' -%>


### PR DESCRIPTION
If you declare a domain name in a `dhcp::pool` declaration, the dhcp subnet block that gets generated has the domain name as a bare word, with no quotes:

    #################################
    # test-pool 10.1.2.0 255.255.255.0
    #################################
    subnet 10.1.2.0 netmask 255.255.255.0 {
    
      option domain-name example.com;
      option subnet-mask 255.255.255.0;
      option routers 10.1.2.1;
      option domain-name-servers 10.1.2.3;
    }

This is not legal syntax - the domain name must be quoted:

      option domain-name "example.com";