### PR TITLE
Enable Ignore unknown clients in templating

### DIFF
--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -11,6 +11,7 @@ define dhcp::pool (
   $nameservers = undef,
   $pxeserver   = undef,
   $domain_name = '',
+  $ignore_unknown = undef,
 ) {
 
   include dhcp::params

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -8,6 +8,9 @@ subnet <%= @network %> netmask <%= @mask %> {
 <% if @failover != '' -%>
     failover peer "<%= @failover %>";
 <% end -%>
+<% if @ignore_unknown == true -%>
+    ignore unknown-clients ;
+<% end -%>
 <% if @range and @range.is_a? Array -%>
 <% @range.each do |r| -%>
     range <%= r %>;


### PR DESCRIPTION
Enabling ignore unknown-clients, this is a fairly useful feature especially if you are operating within more complex DHCP set-ups. It's enabled on a per pool level as configuring it on the global config level severely cripples reconfigurability.