### PR TITLE
do not sort pool dns servers list

### DIFF
--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -40,7 +40,7 @@ subnet <%= @network %> netmask <%= @mask %> {
   <%= @parameters %>;
 <% end -%>
 <% if @nameservers and @nameservers.is_a? Array -%>
-  option domain-name-servers <%= @nameservers.sort.join(', ') %>;
+  option domain-name-servers <%= @nameservers.join(', ') %>;
 <% elsif @nameservers -%>
   option domain-name-servers <%= @nameservers %>;
 <% end -%>


### PR DESCRIPTION
dns servers in dhcp are listed in priority order.  by sorting the
dns server list, you are destroying the priority order specified
by the person calling the defined type.