### PR TITLE
Add the ability to add extra configurations in plain-text

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,7 @@ class dhcp (
   $service_ensure      = running,
   $globaloptions       = '',
   $omapi_port          = undef,
+  $extra_config        = '',
 ) {
 
   if $dnsdomain == undef {

--- a/templates/dhcpd.conf-extra.erb
+++ b/templates/dhcpd.conf-extra.erb
@@ -2,4 +2,8 @@
 include "<%= @dhcp_dir %>/dhcpd.pools";
 include "<%= @dhcp_dir %>/dhcpd.hosts";
 include "<%= @dhcp_dir %>/dhcpd.ignoredsubnets";
+<% if @extra_config && !@extra_config.empty? -%>
+# extra_config
+<%= @extra_config %>
+<% end -%>
 # END DHCP Extra configurations


### PR DESCRIPTION
Currently this is the only way I can think of to add conditional logic to the configuration file.  For instance, I need this in dhcpd.conf for razor:

if exists user-class and option user-class = "iPXE" {
    filename "bootstrap.ipxe";
} else {
    filename "undionly.kpxe";
}