### PR TITLE
Add support for iPXE chain loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,21 @@ Create host reservations.
       ip  => '10.0.1.51',
     }
 
+### parameters
+Parameters are available to configure pxe or ipxe
+
+Boot ipxe from pxe. When configured this overrides pxefilename.
+For more information see [ipxe.org](http://ipxe.org/howto/chainloading).
+
+    class { 'dhcp':
+      ipxe_filename  => 'undionly.kpxe',
+      ipxe_bootstrap => 'bootstrap.kpxe',
+      pxeserver      => '10.0.1.50',
+    }
+
 ## Contributors
 Zach Leslie <zach.leslie@gmail.com>
 Ben Hughes <git@mumble.org.uk>
 Sam Dunster <sdunster@uow.edu.au>
 Garrett Honeycutt <gh@learnpuppet.com>
+Matt Kirby <mk.kirby@gmail.com>

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,8 @@ class dhcp (
   $dnskeyname          = undef,
   $pxeserver           = undef,
   $pxefilename         = undef,
+  $ipxe_filename       = undef,
+  $ipxe_bootstrap      = undef,
   $logfacility         = 'daemon',
   $default_lease_time  = 3600,
   $max_lease_time      = 86400,
@@ -37,6 +39,18 @@ class dhcp (
 
   validate_array($nameservers)
   validate_array($ntpservers)
+
+  if $pxeserver or $pxefilename {
+    if ! $pxeserver or ! $pxefilename {
+      fail( '$pxeserver and $pxefilename are required when enabling pxe' )
+    }
+  }
+
+  if $ipxe_filename or $ipxe_bootstrap {
+    if ! $ipxe_filename or ! $ipxe_bootstrap {
+      fail( '$ipxe_filename and $ipxe_bootstrap are required when enabling ipxe' )
+    }
+  }
 
   include dhcp::params
   include dhcp::monitor

--- a/spec/classes/dhcp_spec.rb
+++ b/spec/classes/dhcp_spec.rb
@@ -273,4 +273,41 @@ describe 'dhcp', :type => :class do
     end
   end
 
+  context 'pxeserver defined' do
+    let :params do
+      default_params.merge({
+        :pxeserver   => '1.2.3.4',
+        :pxefilename => 'pxelinux.0',
+      })
+    end
+
+    it do
+      content = subject.resource('concat::fragment', 'dhcp-conf-pxe').send(:parameters)[:content]
+      expected_lines = [ 'filename "pxelinux.0"', 'next-server 1.2.3.4' ]
+      expect(content.split("\n").reject {|l| l =~ /^#|^$/ }).to eq(expected_lines)
+    end
+
+    context 'ipxefilename defined' do
+      let :params do
+        default_params.merge({
+          :ipxe_filename  => 'undionly-20140116.kpxe',
+          :ipxe_bootstrap => 'bootstrap.kpxe',
+        })
+      end
+
+      it do
+        content = subject.resource('concat::fragment', 'dhcp-conf-pxe').send(:parameters)[:content]
+        expected_lines = [
+          'if exists user-class and option user-class = "iPXE" {',
+          'filename "bootstrap.kpxe";',
+          '} else {',
+          'filename "undionly-20140116.kpxe";',
+          '}',
+          'next-server 1.2.3.4',
+        ]
+        expect(content.split("\n").reject {|l| l =~ /^#|^$/ }).to eq(expected_lines)
+      end
+    end
+  end
+
 end

--- a/templates/dhcpd.conf.pxe.erb
+++ b/templates/dhcpd.conf.pxe.erb
@@ -1,6 +1,14 @@
 # BEGIN PXE Section
-<% if @pxeserver and @pxefilename then -%>
-next-server <%= @pxeserver %>;
+<% if @ipxe_filename and @ipxe_bootstrap then -%>
+if exists user-class and option user-class = "iPXE" {
+      filename "<%= @ipxe_bootstrap %>";
+} else {
+      filename "<%= @ipxe_filename %>";
+}
+<% elsif @pxefilename then -%>
 filename "<%= @pxefilename %>";
+<% end -%>
+<% if @pxeserver then -%>
+next-server <%= @pxeserver %>;
 <% end -%>
 # END PXE Section

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,17 +1,19 @@
 $ddnskeyname = 'dhcp_updater'
 
 class { 'dhcp':
-  dnsdomain    => [
+  dnsdomain      => [
     'example.com',
     '1.1.10.in-addr.arpa',
     ],
-  nameservers  => ['10.1.1.10'],
-  ntpservers   => ['us.pool.ntp.org'],
-  interfaces   => ['eth0'],
-  dnsupdatekey => "/etc/bind/keys.d/${ddnskeyname}",
-  require      => Bind::Key[ $ddnskeyname ],
-  pxeserver    => '10.1.1.5',
-  pxefilename  => 'pxelinux.0',
+  nameservers    => ['10.1.1.10'],
+  ntpservers     => ['us.pool.ntp.org'],
+  interfaces     => ['eth0'],
+  dnsupdatekey   => "/etc/bind/keys.d/${ddnskeyname}",
+  require        => Bind::Key[ $ddnskeyname ],
+  pxeserver      => '10.1.1.5',
+  pxefilename    => 'pxelinux.0',
+  ipxe_filename  => 'undionly.kpxe',
+  ipxe_bootstrap => 'bootstrap.kpxe',
 }
 
 dhcp::pool{ 'example.com':


### PR DESCRIPTION
This commit adds support for iPXE chain loading, which allows a user to
specify a ipxe file and bootstrap script. When configured pxe will load
ipxe, which will then load the bootstrap script. This is helpful for
applications that use ipxe to load, like razor. Without this change it
is not possible to chain pxe to ipxe.