### PR TITLE
Fix typo in spec test

### DIFF
--- a/spec/classes/dhcp_spec.rb
+++ b/spec/classes/dhcp_spec.rb
@@ -175,7 +175,7 @@ describe 'dhcp', :type => :class do
       end
     end
   end
-  context 'on a Dawin OS' do
+  context 'on a Darwin OS' do
     let :facts do
       {
         :osfamily               => 'Darwin',


### PR DESCRIPTION
This commit fixes a typo in dhcp spec tests. Specifically, Dawin is corrected to Darwin.